### PR TITLE
Update pyTUID to be Django 2.0 compatible (requires django >=1.10)

### DIFF
--- a/pyTUID/mixins.py
+++ b/pyTUID/mixins.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.http import HttpResponseRedirect
 from django.core.exceptions import PermissionDenied, ImproperlyConfigured

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='pyTUID',
-    version='1.2.0',
+    version='1.2.1',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',


### PR DESCRIPTION
This change was proposed in and should resolve #11. It is compatible and tested with the django version currently deployed for the website, as we are using 1.10 already. We will need to stay compatible with django 1.x, until djangocms is released for django 2.0.